### PR TITLE
refactor: centralize loader utility

### DIFF
--- a/public/index-page.js
+++ b/public/index-page.js
@@ -7,6 +7,7 @@ import {
     checkWeekendWarrior,
     checkFamilyFeast
 } from './utils/calculators.js';
+import { showLoader, hideLoader } from './utils/loader.js';
 
 document.addEventListener('DOMContentLoaded', function() {
     // Only run this script on the main page by checking for a unique element
@@ -233,20 +234,6 @@ document.addEventListener('DOMContentLoaded', function() {
         if (!bounds.isEmpty()) {
             map.fitBounds(bounds, { padding: 50, maxZoom: 15 });
         }
-    }
-
-    function showLoader() {
-        const loader = document.getElementById('loader-container');
-        if(loader) loader.style.opacity = '1';
-        if(loader) loader.style.visibility = 'visible';
-    }
-
-    function hideLoader() {
-        const loader = document.getElementById('loader-container');
-        if(loader) loader.style.opacity = '0';
-        setTimeout(() => {
-            if(loader) loader.style.visibility = 'hidden';
-        }, 300);
     }
 
     initializeDashboard();

--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -1,3 +1,5 @@
+import { showLoader, hideLoader } from './utils/loader.js';
+
 let currentPage = 1;
 const itemsPerPage = 10;
 let allActivities = [];
@@ -219,13 +221,3 @@ function setupEventListeners() {
     });
 }
 
-
-function showLoader() {
-    const loader = document.getElementById('loader-container');
-    if(loader) loader.style.display = 'flex';
-}
-
-function hideLoader() {
-    const loader = document.getElementById('loader-container');
-    if(loader) loader.style.display = 'none';
-}

--- a/public/utils/loader.js
+++ b/public/utils/loader.js
@@ -1,0 +1,19 @@
+export function showLoader() {
+    const loader = document.getElementById('loader-container');
+    if (loader) {
+        loader.style.display = 'flex';
+        loader.style.opacity = '1';
+        loader.style.visibility = 'visible';
+    }
+}
+
+export function hideLoader() {
+    const loader = document.getElementById('loader-container');
+    if (loader) {
+        loader.style.opacity = '0';
+        setTimeout(() => {
+            loader.style.visibility = 'hidden';
+            loader.style.display = 'none';
+        }, 300);
+    }
+}


### PR DESCRIPTION
## Summary
- extract loader overlay helpers to `public/utils/loader.js`
- import shared `showLoader`/`hideLoader` in index and restaurant pages
- remove duplicated loader functions

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b692dc8d6883229add3457235a9304