### PR TITLE
Add site password and restaurant view ID to env example

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -1,3 +1,5 @@
 AIRTABLE_API_KEY=your_airtable_api_key_here
 AIRTABLE_BASE_ID=your_airtable_base_id_here
 MAPBOX_PUBLIC_TOKEN=your_mapbox_public_token_here
+SITE_PASSWORD=your_site_password_here
+AIRTABLE_RESTAURANT_VIEW_ID=your_view_id_here


### PR DESCRIPTION
## Summary
- include site password placeholder in example env file
- document Airtable restaurant view ID in env example

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b691a4fc90832297399fc53928b2fa