### PR TITLE
feat: add added sort option for restaurants

### DIFF
--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -32,6 +32,7 @@ async function initializePage() {
 
         const records = airtableData.records || [];
         allActivities = processActivityData(records);
+        allActivities.sort((a, b) => b.date - a.date);
         currentActivities = [...allActivities];
 
         initializeMap(tokenData.token, allActivities);
@@ -56,6 +57,7 @@ function processActivityData(records) {
             country: record.fields.Riik || 'N/A',
             spend: record.fields.Kokku || 0,
             date: new Date(record.fields.Kuupäev),
+            added: new Date(record.createdTime),
             coordinates: record.fields.coordinates || (record.fields.lat_exif && record.fields.lon_exif ? `${record.fields.lat_exif},${record.fields.lon_exif}` : null),
             photoUrl: record.fields.Attachments?.[0]?.thumbnails?.large?.url,
             emoji: record.fields.Emoji || ''
@@ -193,6 +195,8 @@ function setupEventListeners() {
 
         if (sortValue === 'date') {
             filtered.sort((a, b) => b.date - a.date);
+        } else if (sortValue === 'added') {
+            filtered.sort((a, b) => b.added - a.added);
         } else if (sortValue === 'avg-spend') {
             filtered.sort((a, b) => b.spend - a.spend);
         }

--- a/public/restaurants.html
+++ b/public/restaurants.html
@@ -81,6 +81,7 @@
                         <label for="sort-by" class="text-white">Sort by:</label>
                         <select id="sort-by" class="p-2 rounded-md bg-gray-800 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-color">
                             <option value="date">Date</option>
+                            <option value="added">Added</option>
                             <option value="avg-spend">Spend</option>
                         </select>
                     </div>


### PR DESCRIPTION
## Summary
- allow sorting restaurants by when they were added
- keep default sort by visit date

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b697b229b8832280d83e6f9e92560b