### PR TITLE
Trim search input before filtering restaurants

### DIFF
--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -183,7 +183,7 @@ function setupEventListeners() {
     const nextButton = document.getElementById('next-page');
 
     function filterAndSort() {
-        const searchTerm = searchInput.value.toLowerCase();
+        const searchTerm = searchInput.value.trim().toLowerCase();
         const sortValue = sortBy.value;
 
         let filtered = allActivities.filter(a => 


### PR DESCRIPTION
## Summary
- Trim leading/trailing whitespace from restaurant search input before filtering

## Testing
- `node - <<'NODE' ...` (sample filter with ' sushi ')
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b69e7ecce4832288d5e995bd369675