### PR TITLE
Debounce restaurant search input

### DIFF
--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -6,6 +6,7 @@ let allActivities = [];
 let currentActivities = [];
 let map;
 const markers = {};
+let debounceTimer;
 
 document.addEventListener('DOMContentLoaded', () => {
     initializePage();
@@ -206,7 +207,10 @@ function setupEventListeners() {
         renderActivityList();
     }
 
-    searchInput.addEventListener('input', filterAndSort);
+    searchInput.addEventListener('input', () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(filterAndSort, 300);
+    });
     sortBy.addEventListener('change', filterAndSort);
 
     prevButton.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add debounce timer for restaurant search input
- delay filtering until user stops typing for 300ms

## Testing
- `npm test` *(fails: no test specified)*
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b69e7d98d48322891a71b31422402f