### PR TITLE
Improve restaurants page mobile layout

### DIFF
--- a/public/restaurants.html
+++ b/public/restaurants.html
@@ -72,8 +72,8 @@
                 </div>
             </header>
 
-            <div class="flex gap-8">
-                <div class="w-1/3">
+            <div class="flex flex-col md:flex-row gap-8">
+                <div class="w-full md:w-1/3">
                     <div class="mb-4 flex items-center gap-2">
                         <input type="text" id="search-input" placeholder="Search by name, city, or country..." class="flex-1 p-2 rounded-md bg-gray-800 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-color">
                         <button id="clear-search" class="p-2 rounded-md bg-gray-800 text-white border border-gray-700 hover:bg-gray-700">Clear</button>
@@ -95,7 +95,7 @@
                         <button id="next-page" class="p-2 rounded-md bg-gray-800 text-white border border-gray-700 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed">Next</button>
                     </div>
                 </div>
-                <div class="w-2/3">
+                <div class="w-full md:w-2/3 h-64 md:h-auto">
                     <div id="map" class="h-full w-full rounded-lg"></div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Stack restaurant list and map vertically on small screens for better readability
- Give map a fixed mobile height and responsive widths to prevent overflow

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b5eca6c88322876d517ed62f81f5