### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
     </div>
 
     <div class="flex min-h-screen">
-        <aside class="w-64 bg-gray-900/50 p-6 flex-col justify-between hidden md:flex">
+        <aside id="sidebar" class="fixed inset-y-0 left-0 z-50 w-64 bg-gray-900/50 p-6 flex flex-col justify-between transform -translate-x-full transition-transform duration-300 md:relative md:translate-x-0" aria-hidden="true" tabindex="-1">
             <div>
                 <div class="flex items-center gap-3 mb-10">
                     <svg class="text-[var(--primary-color)]" fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
@@ -64,10 +64,11 @@
                 </a>
             </div>
         </aside>
+        <div id="sidebar-overlay" class="fixed inset-0 bg-black/50 z-40 hidden" tabindex="-1" aria-hidden="true"></div>
         <main class="flex-1 p-4 sm:p-8 overflow-y-auto">
             <header class="mb-8 flex flex-col sm:flex-row justify-between sm:items-center gap-4">
                 <div class="flex items-center gap-4">
-                    <button class="md:hidden text-white">
+                    <button id="menu-button" class="md:hidden text-white" aria-controls="sidebar" aria-expanded="false" aria-label="Open menu">
                         <span class="material-symbols-outlined">menu</span>
                     </button>
                     <div>
@@ -191,6 +192,7 @@
             </div>
         </main>
     </div>
+    <script src="utils/menu.js" defer></script>
     <script src="index-page.js" type="module"></script>
     <script>
         document.getElementById('logout-button').addEventListener('click', async (event) => {

--- a/public/restaurants.html
+++ b/public/restaurants.html
@@ -17,7 +17,7 @@
         <div class="spinner"></div>
     </div>
     <div class="flex min-h-screen">
-        <aside class="w-64 bg-gray-900/50 p-6 flex-col justify-between hidden md:flex">
+        <aside id="sidebar" class="fixed inset-y-0 left-0 z-50 w-64 bg-gray-900/50 p-6 flex flex-col justify-between transform -translate-x-full transition-transform duration-300 md:relative md:translate-x-0" aria-hidden="true" tabindex="-1">
             <div>
                 <div class="flex items-center gap-3 mb-10">
                     <svg class="text-[var(--primary-color)]" fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
@@ -61,9 +61,10 @@
                 </a>
             </div>
         </aside>
+        <div id="sidebar-overlay" class="fixed inset-0 bg-black/50 z-40 hidden" tabindex="-1" aria-hidden="true"></div>
         <main class="flex-1 p-4 sm:p-8 overflow-y-auto">
             <header class="mb-8 flex items-center gap-4">
-                <button class="md:hidden text-white">
+                <button id="menu-button" class="md:hidden text-white" aria-controls="sidebar" aria-expanded="false" aria-label="Open menu">
                     <span class="material-symbols-outlined">menu</span>
                 </button>
                 <div>
@@ -102,6 +103,7 @@
         </main>
     </div>
 
+    <script src="utils/menu.js" defer></script>
     <script src="restaurants-page.js" type="module"></script>
     <script>
         document.getElementById('logout-button').addEventListener('click', async (event) => {

--- a/public/spending.html
+++ b/public/spending.html
@@ -16,7 +16,7 @@
         <div class="spinner"></div>
     </div>
     <div class="flex min-h-screen">
-        <aside class="w-64 bg-gray-900/50 p-6 flex-col justify-between hidden md:flex">
+        <aside id="sidebar" class="fixed inset-y-0 left-0 z-50 w-64 bg-gray-900/50 p-6 flex flex-col justify-between transform -translate-x-full transition-transform duration-300 md:relative md:translate-x-0" aria-hidden="true" tabindex="-1">
             <div>
                 <div class="flex items-center gap-3 mb-10">
                     <svg class="text-[var(--primary-color)]" fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
@@ -60,9 +60,10 @@
                 </a>
             </div>
         </aside>
+        <div id="sidebar-overlay" class="fixed inset-0 bg-black/50 z-40 hidden" tabindex="-1" aria-hidden="true"></div>
         <main class="flex-1 p-4 sm:p-8 overflow-y-auto">
             <header class="mb-8 flex items-center gap-4">
-                <button class="md:hidden text-white">
+                <button id="menu-button" class="md:hidden text-white" aria-controls="sidebar" aria-expanded="false" aria-label="Open menu">
                     <span class="material-symbols-outlined">menu</span>
                 </button>
                 <div>
@@ -89,6 +90,7 @@
         </main>
     </div>
 
+    <script src="utils/menu.js" defer></script>
     <script src="spending-page.js" type="module"></script>
     <script>
         document.getElementById('logout-button').addEventListener('click', async (event) => {

--- a/public/utils/menu.js
+++ b/public/utils/menu.js
@@ -1,0 +1,55 @@
+const menuButton = document.getElementById('menu-button');
+const sidebar = document.getElementById('sidebar');
+const overlay = document.getElementById('sidebar-overlay');
+
+if (menuButton && sidebar && overlay) {
+  const focusableSelectors = 'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  let lastFocusedElement = null;
+
+  const openMenu = () => {
+    lastFocusedElement = document.activeElement;
+    sidebar.classList.remove('-translate-x-full');
+    overlay.classList.remove('hidden');
+    document.body.classList.add('overflow-hidden');
+    menuButton.setAttribute('aria-expanded', 'true');
+    sidebar.setAttribute('aria-hidden', 'false');
+    const firstFocusable = sidebar.querySelector(focusableSelectors);
+    if (firstFocusable) firstFocusable.focus();
+  };
+
+  const closeMenu = () => {
+    sidebar.classList.add('-translate-x-full');
+    overlay.classList.add('hidden');
+    document.body.classList.remove('overflow-hidden');
+    menuButton.setAttribute('aria-expanded', 'false');
+    sidebar.setAttribute('aria-hidden', 'true');
+    if (lastFocusedElement) lastFocusedElement.focus();
+  };
+
+  const trapFocus = (e) => {
+    if (e.key !== 'Tab') return;
+    const focusable = sidebar.querySelectorAll(focusableSelectors);
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey && document.activeElement === first) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && document.activeElement === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  };
+
+  menuButton.addEventListener('click', () => {
+    const expanded = menuButton.getAttribute('aria-expanded') === 'true';
+    expanded ? closeMenu() : openMenu();
+  });
+
+  overlay.addEventListener('click', closeMenu);
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && menuButton.getAttribute('aria-expanded') === 'true') {
+      closeMenu();
+    }
+  });
+  sidebar.addEventListener('keydown', trapFocus);
+}


### PR DESCRIPTION
## Summary
- add ARIA attributes and defer loading for hamburger menu across pages
- enhance menu script with focus management, scroll locking, and keyboard support

## Testing
- `npm test` (fails: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6b7e380688322a76717311761d97c