### PR TITLE
Add heatmap view with selectable metric

### DIFF
--- a/public/index-page.js
+++ b/public/index-page.js
@@ -141,11 +141,48 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     let map;
+    let heatmapMode = 'count';
+
+    function aggregateBills(bills) {
+        const locations = {};
+        bills.forEach(bill => {
+            if (!bill.coordinates) return;
+            const key = bill.coordinates;
+            const amount = bill.Kokku || 0;
+            if (!locations[key]) {
+                locations[key] = { sum: 0, count: 0, coords: key };
+            }
+            locations[key].sum += amount;
+            locations[key].count += 1;
+        });
+
+        const features = Object.values(locations).map(loc => {
+            const [lat, lng] = loc.coords.split(',').map(Number);
+            const avg = loc.count ? loc.sum / loc.count : 0;
+            return {
+                type: 'Feature',
+                geometry: { type: 'Point', coordinates: [lng, lat] },
+                properties: { avgPrice: avg, count: loc.count }
+            };
+        });
+
+        return { type: 'FeatureCollection', features };
+    }
+
+    function getHeatmapWeight(mode) {
+        if (mode === 'avgPrice') {
+            return ['interpolate', ['linear'], ['get', 'avgPrice'], 0, 0, 100, 1];
+        }
+        return ['interpolate', ['linear'], ['get', 'count'], 0, 0, 10, 1];
+    }
+
     function updateMap(bills) {
         if (!mapboxToken) {
             console.error('❌ Mapbox token not available. Cannot initialize map.');
             return;
         }
+
+        const geojson = aggregateBills(bills);
 
         if (!map) {
             mapboxgl.accessToken = mapboxToken;
@@ -169,70 +206,58 @@ document.addEventListener('DOMContentLoaded', function() {
                 } else {
                     originalParent.appendChild(mapContainer);
                 }
-                
+
                 const icon = fullscreenBtn.querySelector('.material-symbols-outlined');
                 icon.textContent = isFullscreen ? 'fullscreen_exit' : 'fullscreen';
 
-                setTimeout(() => map.resize(), 10); 
+                setTimeout(() => map.resize(), 10);
             });
+
+            const heatmapSelect = document.getElementById('heatmap-type');
+            if (heatmapSelect) {
+                heatmapSelect.addEventListener('change', () => {
+                    heatmapMode = heatmapSelect.value === 'price' ? 'avgPrice' : 'count';
+                    if (map.getLayer('bills-heat')) {
+                        map.setPaintProperty('bills-heat', 'heatmap-weight', getHeatmapWeight(heatmapMode));
+                    }
+                });
+            }
+
+            map.on('load', () => {
+                map.addSource('bills', { type: 'geojson', data: geojson });
+                map.addLayer({
+                    id: 'bills-heat',
+                    type: 'heatmap',
+                    source: 'bills',
+                    maxzoom: 15,
+                    paint: {
+                        'heatmap-weight': getHeatmapWeight(heatmapMode),
+                        'heatmap-intensity': 1,
+                        'heatmap-color': [
+                            'interpolate', ['linear'], ['heatmap-density'],
+                            0, 'rgba(0, 0, 255, 0)',
+                            0.5, 'rgb(0, 255, 0)',
+                            1, 'rgb(255, 0, 0)'
+                        ],
+                        'heatmap-radius': 20,
+                        'heatmap-opacity': 0.8
+                    }
+                });
+                fitBounds();
+            });
+        } else {
+            if (map.isStyleLoaded() && map.getSource('bills')) {
+                map.getSource('bills').setData(geojson);
+                fitBounds();
+            }
         }
 
-        if (map.markers) {
-            map.markers.forEach(marker => marker.remove());
-        }
-        map.markers = [];
-
-        const validBills = bills.filter(bill => bill.coordinates);
-        if (validBills.length === 0) return;
-
-        const bounds = new mapboxgl.LngLatBounds();
-
-        validBills.forEach(bill => {
-            const [lat, lng] = bill.coordinates.split(',').map(Number);
-            if (isNaN(lat) || isNaN(lng)) return;
-
-            const restaurantName = bill.Nimetus || 'Unknown Restaurant';
-            const dishName = bill.Toit || 'Dish';
-            const emoji = bill.Emoji || '🍽️';
-            const amount = bill.Kokku || 0;
-            const date = bill.Kuupäev ? new Date(bill.Kuupäev).toLocaleDateString('et-EE') : 'N/A';
-
-            let markerColor = '#10b981'; // Green for €
-            if (amount > 75) markerColor = '#ef4444'; // Red for €€€
-            else if (amount > 35) markerColor = '#f59e0b'; // Yellow for €€
-
-            const el = document.createElement('div');
-            el.className = 'marker';
-            el.style.backgroundColor = markerColor;
-            el.style.width = '20px';
-            el.style.height = '20px';
-            el.style.borderRadius = '50%';
-            el.style.border = '2px solid white';
-
-            const popupElement = document.createElement('div');
-            popupElement.innerHTML = `
-                <h3>${emoji} ${dishName}</h3>
-                <p><strong>${restaurantName}</strong></p>
-                <p>€${amount.toFixed(2)} on ${date}</p>
-            `;
-
-            const popup = new mapboxgl.Popup({ 
-                    offset: 25,
-                    className: 'foodie-popup'
-                })
-                .setDOMContent(popupElement);
-
-            const marker = new mapboxgl.Marker(el)
-                .setLngLat([lng, lat])
-                .setPopup(popup)
-                .addTo(map);
-            
-            map.markers.push(marker);
-            bounds.extend([lng, lat]);
-        });
-
-        if (!bounds.isEmpty()) {
-            map.fitBounds(bounds, { padding: 50, maxZoom: 15 });
+        function fitBounds() {
+            const bounds = new mapboxgl.LngLatBounds();
+            geojson.features.forEach(f => bounds.extend(f.geometry.coordinates));
+            if (!bounds.isEmpty()) {
+                map.fitBounds(bounds, { padding: 50, maxZoom: 15 });
+            }
         }
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -162,10 +162,12 @@
                         <h2 class="text-xl font-semibold text-white mb-4">Your Foodie Map</h2>
                         <div class="flex justify-between items-center mb-4">
                             <p class="text-sm text-[var(--text-secondary)]">Discover where your taste buds have taken you.</p>
-                            <div class="flex items-center gap-4 text-xs text-[var(--text-secondary)]">
-                                <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-full bg-[var(--primary-color)]"></span>€</div>
-                                <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-full bg-[var(--accent-yellow)]"></span>€€</div>
-                                <div class="flex items-center gap-2"><span class="w-3 h-3 rounded-full bg-[var(--accent-red)]"></span>€€€</div>
+                            <div class="flex items-center gap-2 text-xs text-[var(--text-secondary)]">
+                                <label for="heatmap-type" class="mr-2">Show:</label>
+                                <select id="heatmap-type" class="bg-[var(--background-color)] border border-[var(--border-color)] rounded px-2 py-1 text-white">
+                                    <option value="count">Visits</option>
+                                    <option value="price">Avg Price</option>
+                                </select>
                             </div>
                         </div>
                         <div id="map-card-content">


### PR DESCRIPTION
## Summary
- Replace front page map markers with a heatmap
- Allow toggling between visit count and average price

## Testing
- `npm run build`
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b7c98902388322841d380a879ef15e