### PR TITLE
Fix tooltip visibility on spending cards

### DIFF
--- a/public/spending-page.js
+++ b/public/spending-page.js
@@ -92,6 +92,8 @@ function processAndRenderInsights(records) {
         }
     });
 
+    initTooltips();
+
     // Render charts and animations after a short delay to ensure DOM is updated
     setTimeout(() => {
         chartInsights.forEach(insight => {
@@ -203,11 +205,11 @@ function createInsightCard(title, value, isChart = false, icon = 'info', color =
         ? value 
         : `<div class="text-3xl font-bold text-white mt-4 font-poppins" ${isNumeric ? `data-countup="${parseFloat(value)}"` : ''}>${isNumeric ? '0' : value}</div>`;
 
-    const tooltipHtml = description 
-        ? `<div class="tooltip-container">
+    const tooltipHtml = description
+        ? `<div class="tooltip-container" tabindex="0" role="button">
                <span class="material-symbols-outlined">info</span>
                <span class="tooltip-text">${description}</span>
-           </div>` 
+           </div>`
         : '';
 
     const card = `
@@ -234,6 +236,14 @@ function createAchievementBadge(name, description, unlocked = false, icon = 'mil
         </div>
     `;
     return badge;
+}
+
+function initTooltips() {
+    document.querySelectorAll('.tooltip-container').forEach(container => {
+        container.addEventListener('click', () => {
+            container.classList.toggle('active');
+        });
+    });
 }
 
 // --- Animation Helper ---

--- a/src/input.css
+++ b/src/input.css
@@ -132,10 +132,11 @@ body.body-no-scroll {
     line-height: 1.25rem;
 }
 
-.tooltip-container:hover .tooltip-text {
+.tooltip-container:hover .tooltip-text,
+.tooltip-container:focus .tooltip-text,
+.tooltip-container.active .tooltip-text {
     visibility: visible;
     opacity: 1;
-    position: relative;
 }
 
 .foodie-popup .mapboxgl-popup-content {


### PR DESCRIPTION
## Summary
- Remove positioning override that kept tooltip text from appearing
- Allow tooltip activation on click or focus so mobile users can view details

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b9b779d69c8322b10ce41b6ef776d5