### PR TITLE
Add dishes insights page

### DIFF
--- a/public/dishes-page.js
+++ b/public/dishes-page.js
@@ -1,0 +1,440 @@
+import { showLoader, hideLoader } from './utils/loader.js';
+
+let allDishes = [];
+let filteredDishes = [];
+const chartInstances = {};
+
+document.addEventListener('DOMContentLoaded', () => {
+    initializePage();
+});
+
+async function initializePage() {
+    showLoader();
+    try {
+        const response = await fetch('/api/airtable');
+        if (response.status === 401) {
+            window.location.href = '/login.html';
+            return;
+        }
+        if (!response.ok) {
+            throw new Error(`API call failed with status: ${response.status}`);
+        }
+
+        const data = await response.json();
+        const records = data.records || [];
+        allDishes = flattenDishes(records);
+        filteredDishes = [...allDishes];
+
+        renderSummary(allDishes);
+        renderSpendTypeBreakdown(allDishes);
+        renderCharts(allDishes);
+        renderTable(filteredDishes);
+        setupSearch();
+    } catch (error) {
+        console.error('Failed to initialize dishes page:', error);
+        const tableBody = document.getElementById('dish-table-body');
+        if (tableBody) {
+            tableBody.innerHTML = `<tr><td colspan="7" class="px-4 py-6 text-center text-red-400">Failed to load dishes data.</td></tr>`;
+        }
+    } finally {
+        hideLoader();
+    }
+}
+
+function flattenDishes(records) {
+    const dishes = [];
+
+    records.forEach(record => {
+        const fields = record.fields || {};
+        const dishDetails = Array.isArray(fields.ToidudDetails) ? fields.ToidudDetails : [];
+        const photos = (fields.Photos || []).concat(fields.Attachments || []);
+        const photoUrls = photos
+            .map(item => item.thumbnails?.small?.url || item.thumbnails?.large?.url || item.url)
+            .filter(Boolean);
+
+        dishDetails.forEach((dishRecord, index) => {
+            const dishFields = dishRecord?.fields || {};
+            const price = parseNumber(dishFields.Maksumus ?? dishFields.Price);
+            const quantity = parseNumber(dishFields.kogus ?? dishFields.Kogus ?? 1) || 1;
+            const totalCostCandidate = parseNumber(dishFields.Kogukulu ?? dishFields.Total);
+            const totalCost = totalCostCandidate > 0 ? totalCostCandidate : (price || 0) * quantity;
+            const dishName = dishFields.Toode || dishFields.Nimetus || 'Unknown dish';
+            const restaurant = dishFields.Restoran || dishFields.Restaurant || fields.Nimetus || 'Unknown restaurant';
+
+            dishes.push({
+                id: `${record.id}-${dishRecord?.id || index}`,
+                dishName,
+                restaurant,
+                country: dishFields.Riik || fields.Riik || '—',
+                city: dishFields.Linn || fields.Linn || '—',
+                price,
+                quantity,
+                totalCost,
+                spendType: fields['Spend Type'] || 'Unclassified',
+                date: fields.Kuupäev ? new Date(fields.Kuupäev) : null,
+                activityName: fields.Nimetus || 'Untitled bill',
+                emoji: dishFields.Emoji || fields.Emoji || '',
+                attachments: photoUrls
+            });
+        });
+    });
+
+    return dishes;
+}
+
+function parseNumber(value) {
+    if (typeof value === 'number') return value;
+    if (typeof value === 'string') {
+        const normalized = value.replace(',', '.').replace(/[^0-9.\-]/g, '');
+        const parsed = parseFloat(normalized);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+    return 0;
+}
+
+function renderSummary(dishes) {
+    const totalDishesEl = document.getElementById('total-dishes');
+    const uniqueDishesEl = document.getElementById('unique-dishes');
+    const averageDishPriceEl = document.getElementById('average-dish-price');
+    const mostFrequentDishEl = document.getElementById('most-frequent-dish');
+    const mostExpensiveDishEl = document.getElementById('most-expensive-dish');
+
+    const totalDishes = dishes.length;
+    const priceValues = dishes.filter(d => d.price > 0).map(d => d.price);
+    const totalPrice = priceValues.reduce((sum, price) => sum + price, 0);
+    const avgPrice = priceValues.length ? totalPrice / priceValues.length : 0;
+
+    const uniqueDishNames = new Set(dishes.map(d => `${d.dishName}|${d.restaurant}`));
+
+    const frequencyMap = dishes.reduce((acc, dish) => {
+        const key = `${dish.dishName}|${dish.restaurant}`;
+        acc[key] = (acc[key] || 0) + 1;
+        return acc;
+    }, {});
+    const mostFrequentEntry = Object.entries(frequencyMap).sort((a, b) => b[1] - a[1])[0];
+    const mostFrequentDish = mostFrequentEntry ? mostFrequentEntry[0].split('|')[0] : '—';
+
+    const mostExpensiveDish = dishes.reduce((maxDish, current) => {
+        if (!maxDish || (current.price || 0) > (maxDish.price || 0)) {
+            return current;
+        }
+        return maxDish;
+    }, null);
+
+    if (totalDishesEl) totalDishesEl.textContent = totalDishes.toLocaleString();
+    if (uniqueDishesEl) uniqueDishesEl.textContent = uniqueDishNames.size.toLocaleString();
+    if (averageDishPriceEl) averageDishPriceEl.textContent = formatCurrency(avgPrice);
+    if (mostFrequentDishEl) mostFrequentDishEl.textContent = mostFrequentDish;
+    if (mostExpensiveDishEl) {
+        if (mostExpensiveDish) {
+            const priceLabel = mostExpensiveDish.price ? formatCurrency(mostExpensiveDish.price) : '€0.00';
+            const location = [mostExpensiveDish.restaurant, mostExpensiveDish.country].filter(Boolean).join(' • ');
+            mostExpensiveDishEl.textContent = `Top splurge: ${mostExpensiveDish.dishName} (${priceLabel})${location ? ` @ ${location}` : ''}`;
+        } else {
+            mostExpensiveDishEl.textContent = 'Top splurge: —';
+        }
+    }
+}
+
+function renderSpendTypeBreakdown(dishes) {
+    const container = document.getElementById('spend-type-breakdown');
+    if (!container) return;
+
+    const totals = dishes.reduce((acc, dish) => acc + (dish.totalCost || 0), 0);
+    const spendTypeMap = dishes.reduce((acc, dish) => {
+        const key = dish.spendType || 'Unclassified';
+        if (!acc[key]) {
+            acc[key] = { count: 0, priceSum: 0, priceCount: 0, totalCost: 0 };
+        }
+        acc[key].count += 1;
+        acc[key].totalCost += dish.totalCost || 0;
+        if (dish.price > 0) {
+            acc[key].priceSum += dish.price;
+            acc[key].priceCount += 1;
+        }
+        return acc;
+    }, {});
+
+    if (Object.keys(spendTypeMap).length === 0) {
+        container.innerHTML = '<p class="text-gray-400">No dishes available to calculate breakdown.</p>';
+        return;
+    }
+
+    container.innerHTML = '';
+    Object.entries(spendTypeMap).forEach(([type, stats]) => {
+        const avgPrice = stats.priceCount ? stats.priceSum / stats.priceCount : 0;
+        const share = totals ? (stats.totalCost / totals) * 100 : 0;
+        const card = document.createElement('div');
+        card.className = 'bg-[var(--background-color)] p-4 rounded-xl border border-[var(--border-color)] hover:border-[var(--primary-color)] transition-colors';
+        card.innerHTML = `
+            <div class="flex items-center justify-between mb-2">
+                <h3 class="text-white text-lg font-semibold">${type}</h3>
+                <span class="text-sm text-[var(--text-secondary)]">${stats.count} dishes</span>
+            </div>
+            <p class="text-2xl font-bold text-[var(--accent-blue)]">${formatCurrency(avgPrice)}</p>
+            <p class="text-sm text-[var(--text-secondary)] mt-2">${share.toFixed(1)}% of dish spend</p>
+        `;
+        container.appendChild(card);
+    });
+}
+
+function renderCharts(dishes) {
+    renderCountryChart(dishes);
+    renderPriceTierChart(dishes);
+    renderMonthlyTrendChart(dishes);
+}
+
+function renderCountryChart(dishes) {
+    const ctx = document.getElementById('countryPriceChart');
+    if (!ctx) return;
+    if (chartInstances.country) {
+        chartInstances.country.destroy();
+    }
+
+    const countryStats = dishes.reduce((acc, dish) => {
+        if (!dish.country || dish.country === '—' || !dish.price) return acc;
+        const key = dish.country;
+        if (!acc[key]) {
+            acc[key] = { priceSum: 0, count: 0 };
+        }
+        acc[key].priceSum += dish.price;
+        acc[key].count += 1;
+        return acc;
+    }, {});
+
+    const ranked = Object.entries(countryStats)
+        .map(([country, stats]) => ({ country, avg: stats.priceSum / stats.count }))
+        .sort((a, b) => b.avg - a.avg)
+        .slice(0, 8);
+
+    if (!ranked.length) {
+        ctx.parentElement.innerHTML += '<p class="text-gray-400">Not enough data to show country comparison.</p>';
+        return;
+    }
+
+    chartInstances.country = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: ranked.map(item => item.country),
+            datasets: [{
+                label: 'Average price',
+                data: ranked.map(item => Number(item.avg.toFixed(2))),
+                backgroundColor: 'rgba(16, 185, 129, 0.6)',
+                borderColor: 'rgba(16, 185, 129, 1)',
+                borderWidth: 1
+            }]
+        },
+        options: {
+            plugins: {
+                legend: { labels: { color: 'white' } }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: 'white', callback: value => `€${value}` },
+                    grid: { color: '#374151' }
+                },
+                x: {
+                    ticks: { color: 'white' },
+                    grid: { color: '#374151' }
+                }
+            }
+        }
+    });
+}
+
+function renderPriceTierChart(dishes) {
+    const ctx = document.getElementById('priceTierChart');
+    if (!ctx) return;
+    if (chartInstances.tiers) {
+        chartInstances.tiers.destroy();
+    }
+
+    const tiers = {
+        '€ (≤15)': 0,
+        '€€ (15-35)': 0,
+        '€€€ (>35)': 0
+    };
+
+    dishes.forEach(dish => {
+        const price = dish.price || 0;
+        if (price <= 15) tiers['€ (≤15)'] += 1;
+        else if (price <= 35) tiers['€€ (15-35)'] += 1;
+        else tiers['€€€ (>35)'] += 1;
+    });
+
+    const hasData = Object.values(tiers).some(count => count > 0);
+    if (!hasData) {
+        ctx.parentElement.innerHTML += '<p class="text-gray-400">Not enough price data for tiers.</p>';
+        return;
+    }
+
+    chartInstances.tiers = new Chart(ctx, {
+        type: 'pie',
+        data: {
+            labels: Object.keys(tiers),
+            datasets: [{
+                label: 'Dishes',
+                data: Object.values(tiers),
+                backgroundColor: ['#10b981', '#f59e0b', '#ef4444']
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: {
+                legend: {
+                    position: 'bottom',
+                    labels: { color: 'white' }
+                }
+            }
+        }
+    });
+}
+
+function renderMonthlyTrendChart(dishes) {
+    const ctx = document.getElementById('monthlyTrendChart');
+    if (!ctx) return;
+    if (chartInstances.monthly) {
+        chartInstances.monthly.destroy();
+    }
+
+    const monthlyStats = dishes.reduce((acc, dish) => {
+        if (!dish.date || !dish.price) return acc;
+        const key = `${dish.date.getFullYear()}-${String(dish.date.getMonth() + 1).padStart(2, '0')}`;
+        if (!acc[key]) {
+            acc[key] = { priceSum: 0, count: 0 };
+        }
+        acc[key].priceSum += dish.price;
+        acc[key].count += 1;
+        return acc;
+    }, {});
+
+    const sortedKeys = Object.keys(monthlyStats).sort();
+    if (!sortedKeys.length) {
+        ctx.parentElement.innerHTML += '<p class="text-gray-400">Not enough dated dishes for trend analysis.</p>';
+        return;
+    }
+
+    const labels = sortedKeys;
+    const averages = labels.map(key => monthlyStats[key].priceSum / monthlyStats[key].count);
+
+    // Calculate 3-month moving average
+    const movingAverage = averages.map((value, index, arr) => {
+        if (index < 2) return null;
+        const slice = arr.slice(index - 2, index + 1);
+        const avg = slice.reduce((sum, val) => sum + val, 0) / slice.length;
+        return avg;
+    });
+
+    chartInstances.monthly = new Chart(ctx, {
+        type: 'line',
+        data: {
+            labels,
+            datasets: [
+                {
+                    label: 'Average dish price',
+                    data: averages.map(value => Number(value.toFixed(2))),
+                    borderColor: 'rgba(16, 185, 129, 1)',
+                    backgroundColor: 'rgba(16, 185, 129, 0.2)',
+                    tension: 0.3
+                },
+                {
+                    label: '3-month moving average',
+                    data: movingAverage.map(value => (value ? Number(value.toFixed(2)) : null)),
+                    borderColor: 'rgba(139, 92, 246, 1)',
+                    backgroundColor: 'rgba(139, 92, 246, 0.2)',
+                    tension: 0.3
+                }
+            ]
+        },
+        options: {
+            plugins: {
+                legend: {
+                    labels: { color: 'white' }
+                }
+            },
+            scales: {
+                y: {
+                    beginAtZero: true,
+                    ticks: { color: 'white', callback: value => `€${value}` },
+                    grid: { color: '#374151' }
+                },
+                x: {
+                    ticks: { color: 'white' },
+                    grid: { color: '#374151' }
+                }
+            }
+        }
+    });
+}
+
+function renderTable(dishes) {
+    const tableBody = document.getElementById('dish-table-body');
+    if (!tableBody) return;
+
+    if (!dishes.length) {
+        tableBody.innerHTML = '<tr><td colspan="7" class="px-4 py-6 text-center text-gray-400">No dishes match your filters.</td></tr>';
+        return;
+    }
+
+    const rows = dishes.map(dish => {
+        const dateLabel = dish.date ? dish.date.toLocaleDateString() : '—';
+        return `
+            <tr class="hover:bg-gray-800/60 transition-colors">
+                <td class="px-4 py-3 whitespace-nowrap text-white">${dish.emoji ? `${dish.emoji} ` : ''}${escapeHtml(dish.dishName)}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${escapeHtml(dish.restaurant)}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${escapeHtml(dish.country || '—')}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${dateLabel}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${dish.price ? formatCurrency(dish.price) : '—'}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${dish.quantity}</td>
+                <td class="px-4 py-3 whitespace-nowrap text-gray-300">${dish.totalCost ? formatCurrency(dish.totalCost) : '—'}</td>
+            </tr>
+        `;
+    }).join('');
+
+    tableBody.innerHTML = rows;
+}
+
+function setupSearch() {
+    const searchInput = document.getElementById('dish-search');
+    const clearButton = document.getElementById('clear-dish-search');
+    if (!searchInput) return;
+
+    searchInput.addEventListener('input', () => {
+        const query = searchInput.value.trim().toLowerCase();
+        if (!query) {
+            filteredDishes = [...allDishes];
+        } else {
+            filteredDishes = allDishes.filter(dish => {
+                return [dish.dishName, dish.restaurant, dish.country]
+                    .filter(Boolean)
+                    .some(value => value.toLowerCase().includes(query));
+            });
+        }
+        renderTable(filteredDishes);
+    });
+
+    if (clearButton) {
+        clearButton.addEventListener('click', () => {
+            searchInput.value = '';
+            filteredDishes = [...allDishes];
+            renderTable(filteredDishes);
+        });
+    }
+}
+
+function formatCurrency(value) {
+    if (!Number.isFinite(value)) return '€0.00';
+    return `€${value.toLocaleString('et-EE', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+}
+
+function escapeHtml(value) {
+    if (value == null) return '';
+    return value
+        .toString()
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}

--- a/public/dishes.html
+++ b/public/dishes.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Dishes - Foodie Dashboard</title>
+    <link href="https://fonts.googleapis.com" rel="preconnect" />
+    <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&amp;family=Poppins:wght@700&amp;display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined" rel="stylesheet" />
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="bg-[var(--background-color)]">
+    <div id="loader-container">
+        <div class="spinner"></div>
+    </div>
+    <div class="flex min-h-screen">
+        <aside id="sidebar" class="fixed inset-y-0 left-0 z-50 w-64 bg-gray-900/50 p-6 flex flex-col justify-between transform -translate-x-full transition-transform duration-300 md:relative md:translate-x-0" aria-hidden="true" tabindex="-1">
+            <div>
+                <div class="flex items-center gap-3 mb-10">
+                    <svg class="text-[var(--primary-color)]" fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewBox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
+                        <path d="M12 2L2 7l10 5 10-5-10-5z"></path>
+                        <path d="M2 17l10 5 10-5"></path>
+                        <path d="M2 12l10 5 10-5"></path>
+                    </svg>
+                    <div class="text-xl font-bold text-white font-poppins">BillDash</div>
+                </div>
+                <nav class="flex flex-col gap-2">
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="index.html">
+                        <span class="material-symbols-outlined">dashboard</span>
+                        <span>Dashboard</span>
+                    </a>
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="spending.html">
+                        <span class="material-symbols-outlined">payments</span>
+                        <span>Spending</span>
+                    </a>
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="restaurants.html">
+                        <span class="material-symbols-outlined">restaurant</span>
+                        <span>Restaurants</span>
+                    </a>
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md bg-[var(--primary-color)] text-white font-semibold" href="dishes.html" aria-current="page">
+                        <span class="material-symbols-outlined">fastfood</span>
+                        <span>Dishes</span>
+                    </a>
+                </nav>
+            </div>
+            <div class="flex flex-col gap-2">
+                <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <span class="material-symbols-outlined">summarize</span>
+                    <span>Reports</span>
+                </a>
+                <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <span class="material-symbols-outlined">settings</span>
+                    <span>Settings</span>
+                </a>
+                <a id="logout-button" class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <span class="material-symbols-outlined">logout</span>
+                    <span>Logout</span>
+                </a>
+            </div>
+        </aside>
+        <div id="sidebar-overlay" class="fixed inset-0 bg-black/50 z-40 hidden" tabindex="-1" aria-hidden="true"></div>
+        <main class="flex-1 p-4 sm:p-8 overflow-y-auto">
+            <header class="mb-8 flex items-center gap-4">
+                <button id="menu-button" class="md:hidden text-white" aria-controls="sidebar" aria-expanded="false" aria-label="Open menu">
+                    <span class="material-symbols-outlined">menu</span>
+                </button>
+                <div>
+                    <h1 class="text-3xl lg:text-4xl font-bold text-white font-poppins">Dish Explorer</h1>
+                    <p class="text-md lg:text-lg text-[var(--text-secondary)]">Dive into every plate to understand your tastes and spending habits.</p>
+                </div>
+            </header>
+
+            <section class="mb-12">
+                <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] hover:border-[var(--primary-color)] transition-all duration-300 transform hover:-translate-y-1">
+                        <p class="text-sm font-medium text-[var(--text-secondary)]">Dishes Logged</p>
+                        <p id="total-dishes" class="text-4xl font-bold text-white mt-2 font-poppins">0</p>
+                        <p class="text-xs text-[var(--text-secondary)] mt-4">Across all bills you've tracked.</p>
+                    </div>
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] hover:border-[var(--accent-purple)] transition-all duration-300 transform hover:-translate-y-1">
+                        <p class="text-sm font-medium text-[var(--text-secondary)]">Unique Dishes</p>
+                        <p id="unique-dishes" class="text-4xl font-bold text-[var(--accent-purple)] mt-2 font-poppins">0</p>
+                        <p class="text-xs text-[var(--text-secondary)] mt-4">Different menu items you've tried.</p>
+                    </div>
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] hover:border-[var(--accent-blue)] transition-all duration-300 transform hover:-translate-y-1">
+                        <p class="text-sm font-medium text-[var(--text-secondary)]">Average Dish Price</p>
+                        <p id="average-dish-price" class="text-4xl font-bold text-[var(--accent-blue)] mt-2 font-poppins">€0.00</p>
+                        <p class="text-xs text-[var(--text-secondary)] mt-4">Based on menu price per dish.</p>
+                    </div>
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] hover:border-[var(--accent-yellow)] transition-all duration-300 transform hover:-translate-y-1">
+                        <p class="text-sm font-medium text-[var(--text-secondary)]">Most Frequent Dish</p>
+                        <p id="most-frequent-dish" class="text-lg font-semibold text-white mt-2 leading-tight">—</p>
+                        <p id="most-expensive-dish" class="text-xs text-[var(--text-secondary)] mt-4">Top splurge: —</p>
+                    </div>
+                </div>
+            </section>
+
+            <section class="mb-12">
+                <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] mb-6">
+                    <h2 class="text-2xl font-semibold text-white mb-6 pb-2 border-b border-[var(--border-color)]">Local vs Travel Taste</h2>
+                    <div id="spend-type-breakdown" class="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <!-- Filled dynamically -->
+                    </div>
+                </div>
+
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] lg:col-span-2">
+                        <h2 class="text-xl font-semibold text-white mb-4">Average Dish Price by Country</h2>
+                        <canvas id="countryPriceChart" height="220"></canvas>
+                    </div>
+                    <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)]">
+                        <h2 class="text-xl font-semibold text-white mb-4">Price Tiers</h2>
+                        <canvas id="priceTierChart" height="220"></canvas>
+                    </div>
+                </div>
+
+                <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)] mt-6">
+                    <h2 class="text-xl font-semibold text-white mb-4">Monthly Dish Price Trend</h2>
+                    <canvas id="monthlyTrendChart" height="260"></canvas>
+                </div>
+            </section>
+
+            <section class="mb-12">
+                <div class="bg-[var(--card-color)] p-6 rounded-2xl border border-[var(--border-color)]">
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+                        <h2 class="text-2xl font-semibold text-white">Dish Library</h2>
+                        <div class="flex gap-2">
+                            <input type="text" id="dish-search" placeholder="Search dishes, restaurants, or countries..." class="flex-1 md:w-80 p-2 rounded-md bg-gray-800 text-white border border-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-color">
+                            <button id="clear-dish-search" class="p-2 rounded-md bg-gray-800 text-white border border-gray-700 hover:bg-gray-700">Clear</button>
+                        </div>
+                    </div>
+                    <div class="overflow-x-auto">
+                        <table class="min-w-full divide-y divide-gray-700">
+                            <thead class="bg-gray-800/60">
+                                <tr>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Dish</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Restaurant</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Country</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Date</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Price</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Qty</th>
+                                    <th class="px-4 py-3 text-left text-xs font-medium text-gray-300 uppercase tracking-wider">Total</th>
+                                </tr>
+                            </thead>
+                            <tbody id="dish-table-body" class="divide-y divide-gray-800">
+                                <!-- Rows inserted dynamically -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </section>
+        </main>
+    </div>
+
+    <script src="utils/menu.js" defer></script>
+    <script src="dishes-page.js" type="module"></script>
+    <script>
+        document.getElementById('logout-button').addEventListener('click', async (event) => {
+            event.preventDefault();
+            try {
+                const response = await fetch('/api/logout', {
+                    method: 'POST',
+                });
+                if (response.ok) {
+                    window.location.href = '/login.html';
+                } else {
+                    console.error('Logout failed');
+                }
+            } catch (error) {
+                console.error('Failed to connect to the server for logout.');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
                         <span class="material-symbols-outlined">restaurant</span>
                         <span>Restaurants</span>
                     </a>
-                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="dishes.html">
                         <span class="material-symbols-outlined">fastfood</span>
                         <span>Dishes</span>
                     </a>

--- a/public/restaurants.html
+++ b/public/restaurants.html
@@ -40,7 +40,7 @@
                         <span class="material-symbols-outlined">restaurant</span>
                         <span>Restaurants</span>
                     </a>
-                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="dishes.html">
                         <span class="material-symbols-outlined">fastfood</span>
                         <span>Dishes</span>
                     </a>

--- a/public/spending.html
+++ b/public/spending.html
@@ -39,7 +39,7 @@
                         <span class="material-symbols-outlined">restaurant</span>
                         <span>Restaurants</span>
                     </a>
-                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="#">
+                    <a class="flex items-center gap-3 px-4 py-2 rounded-md text-[var(--text-secondary)] hover:bg-white/5 hover:text-white transition-colors" href="dishes.html">
                         <span class="material-symbols-outlined">fastfood</span>
                         <span>Dishes</span>
                     </a>


### PR DESCRIPTION
## Summary
- create a dedicated dishes explorer page with summary metrics, charts, and searchable table
- build client logic to flatten Airtable dish records, calculate insights, and render Chart.js visualisations
- update existing navigation to link to the new dishes page
- align the dishes page asset references with the existing layout so it reuses the shared styling stack

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8137f2d4c8322821026d2ea64f994