### PR TITLE
Show recent-visit dishes on restaurants page with truncation and fallback

### DIFF
--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -189,9 +189,27 @@ function formatPriceLevel(priceLevel) {
     return mappedLevel == null ? null : coerceLevel(mappedLevel);
 }
 
+function extractDishNames(fields = {}) {
+    const linkedDishNames = Array.isArray(fields.Toidud)
+        ? fields.Toidud
+            .map(dish => (typeof dish === 'string' ? dish.trim() : ''))
+            .filter(Boolean)
+        : [];
+
+    const detailDishNames = Array.isArray(fields.ToidudDetails)
+        ? fields.ToidudDetails
+            .map(detail => detail?.fields?.Toode || detail?.fields?.Nimetus || '')
+            .map(name => (typeof name === 'string' ? name.trim() : ''))
+            .filter(Boolean)
+        : [];
+
+    return Array.from(new Set([...linkedDishNames, ...detailDishNames]));
+}
+
 function processActivityData(records) {
     return records.map(record => {
         const restaurantDetails = record.fields.ToidudDetails?.[0]?.fields;
+        const dishes = extractDishNames(record.fields);
         const photos = record.fields.Photos || [];
         const attachments = record.fields.Attachments || [];
 
@@ -239,7 +257,8 @@ function processActivityData(records) {
             rating: rating,
             ratingCount,
             priceLevel,
-            googlePlacesId
+            googlePlacesId,
+            dishes
         };
     });
 }
@@ -382,7 +401,20 @@ function renderActivityList() {
                             const visitSpendLabel = visit.peopleCount && visit.peopleCount > 0
                                 ? `€${(visit.spend / visit.peopleCount).toFixed(2)} 👤${visit.peopleCount}`
                                 : `€${visit.spend.toFixed(2)}`;
-                            return `<li>${visit.date.toLocaleDateString()} · ${visitSpendLabel}</li>`;
+                            const visitDishes = Array.isArray(visit.dishes) ? visit.dishes : [];
+                            const maxDishesToShow = 3;
+                            const visibleDishes = visitDishes.slice(0, maxDishesToShow);
+                            const hiddenCount = Math.max(visitDishes.length - maxDishesToShow, 0);
+                            const dishesLabel = visitDishes.length
+                                ? `${visibleDishes.join(', ')}${hiddenCount > 0 ? ` +${hiddenCount} more` : ''}`
+                                : 'No dishes logged';
+
+                            return `
+                                <li>
+                                    <div>${visit.date.toLocaleDateString()} · ${visitSpendLabel}</div>
+                                    <div class="text-xs text-gray-500 ml-5">${dishesLabel}</div>
+                                </li>
+                            `;
                         }).join('')}
                     </ul>
                 </div>

--- a/public/restaurants-page.js
+++ b/public/restaurants-page.js
@@ -189,21 +189,28 @@ function formatPriceLevel(priceLevel) {
     return mappedLevel == null ? null : coerceLevel(mappedLevel);
 }
 
-function extractDishNames(fields = {}) {
-    const linkedDishNames = Array.isArray(fields.Toidud)
-        ? fields.Toidud
-            .map(dish => (typeof dish === 'string' ? dish.trim() : ''))
-            .filter(Boolean)
-        : [];
+function isLikelyAirtableRecordId(value) {
+    return typeof value === 'string' && /^rec[a-zA-Z0-9]{14}$/.test(value.trim());
+}
 
+function extractDishNames(fields = {}) {
     const detailDishNames = Array.isArray(fields.ToidudDetails)
         ? fields.ToidudDetails
-            .map(detail => detail?.fields?.Toode || detail?.fields?.Nimetus || '')
+            .map(detail => {
+                const detailFields = detail?.fields || {};
+                return detailFields.Toode || detailFields.Nimetus || detailFields.Dish || detailFields.Name || '';
+            })
             .map(name => (typeof name === 'string' ? name.trim() : ''))
             .filter(Boolean)
         : [];
 
-    return Array.from(new Set([...linkedDishNames, ...detailDishNames]));
+    const linkedDishNames = Array.isArray(fields.Toidud)
+        ? fields.Toidud
+            .map(dish => (typeof dish === 'string' ? dish.trim() : ''))
+            .filter(dish => dish && !isLikelyAirtableRecordId(dish))
+        : [];
+
+    return Array.from(new Set([...detailDishNames, ...linkedDishNames]));
 }
 
 function processActivityData(records) {


### PR DESCRIPTION
### Motivation
- Surface per-visit dish information on the restaurants list so users can quickly see what was eaten during recent visits. 
- Ensure `recentVisits` retains dish data by attaching dishes to each activity before grouping. 
- Avoid overly large list items by truncating long dish lists and providing a compact fallback.

### Description
- Added `extractDishNames(fields)` to normalize dish names from `fields.Toidud` and linked `fields.ToidudDetails` and wired it into `processActivityData(records)` so each activity now includes a `dishes` array in the returned activity object in `public/restaurants-page.js`.
- Preserved the existing grouping pipeline (`groupActivitiesByPlaceId()` still uses `sortedActivities.slice(0, 3)`), which now carries `visit.dishes` because dishes are attached to activities earlier.
- Updated `renderActivityList()` to render a second line under each recent visit showing up to 3 dish names with a `+N more` indicator for extra dishes and the fallback text `No dishes logged` when none are present.

### Testing
- Ran a syntax check with `node --check public/restaurants-page.js`, which completed successfully. 
- Executed an automated Playwright smoke test that served `public/` with mocked API responses and captured a screenshot (`artifacts/restaurants-dishes-row.png`) to validate dishes rendering, truncation, and fallback, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0d1d6d8c83229b862c035a3feaa0)